### PR TITLE
Update endpoints and add new @me endpoints

### DIFF
--- a/src/api/Auth.js
+++ b/src/api/Auth.js
@@ -1,14 +1,6 @@
 import { callApi } from "../utils/call-api";
 
 /**
- * Gets the currently logged in user.
- * @returns A promise that resolves to the current user
- */
-export const getMe = () => {
-  return callApi("/auth/@me");
-};
-
-/**
  * Logs in a user with the given email and password. This will set a session cookie.
  * @param {string} email
  * @param {string} password
@@ -33,7 +25,7 @@ export const login = (email, password) => {
  */
 export const logout = () => {
   return callApi("/auth/logout", {
-    method: "POST",
+    method: "DELETE",
   });
 };
 
@@ -60,7 +52,6 @@ export const register = (firstName, lastName, email, password) => {
     }),
   });
 };
-
 
 export const updateUniversity = (id, university) => {
   return callApi(`/auth/${id}`, {

--- a/src/api/Me.js
+++ b/src/api/Me.js
@@ -7,7 +7,7 @@ import { callApi } from "../utils/call-api";
  * @returns A promise that resolves when the password is successfully changed
  */
 export const changePassword = (oldPassword, newPassword) => {
-  return callApi("/@me/password", {
+  return callApi("/@me/change-password", {
     method: "PATCH",
     headers: {
       "Content-Type": "application/json",

--- a/src/api/Me.js
+++ b/src/api/Me.js
@@ -1,0 +1,39 @@
+import { callApi } from "../utils/call-api";
+
+/**
+ * Change the password of the currently logged in user.
+ * @param {string} oldPassword The old password of the user. This is used to confirm the change.
+ * @param {string} newPassword The new password of the user.
+ * @returns A promise that resolves when the password is successfully changed
+ */
+export const changePassword = (oldPassword, newPassword) => {
+  return callApi("/@me/password", {
+    method: "PATCH",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      newPassword,
+      oldPassword,
+    }),
+  });
+};
+
+/**
+ * Deletes the account of the currently logged in user.
+ * @param {string} password The password of the user to confirm the deletion
+ * @returns A promise that resolves when the account is successfully deleted
+ */
+export const deleteAccount = (password) => {
+  return callApi("/@me", {
+    method: "DELETE",
+  });
+};
+
+/**
+ * Gets the currently logged in user.
+ * @returns A promise that resolves to the current user
+ */
+export const getMe = () => {
+  return callApi("/@me");
+};

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,7 @@ import * as ReactDOM from "react-dom/client";
 import { RouterProvider } from "react-router-dom";
 import { Provider } from "react-redux";
 
-import { getMe } from "./api/Auth";
+import { getMe } from "./api/Me";
 
 import { router } from "./router";
 

--- a/src/pages/Register.js
+++ b/src/pages/Register.js
@@ -3,7 +3,8 @@ import { useState } from "react";
 import { useDispatch } from "react-redux";
 import { useNavigate, Link } from "react-router-dom";
 
-import { getMe, register } from "../api/Auth";
+import { getMe } from "../api/Me";
+import { register } from "../api/Auth";
 
 import { setUser } from "../store";
 


### PR DESCRIPTION
Added new functions to call the new `@me` endpoints. The function definitions are as follows:

```typescript
/**
 * Change the password of the currently logged in user.
 * @param {string} oldPassword The old password of the user. This is used to confirm the change.
 * @param {string} newPassword The new password of the user.
 * @returns A promise that resolves when the password is successfully changed
 */
export const changePassword = (oldPassword, newPassword) => Promise<void>;

/**
 * Deletes the account of the currently logged in user.
 * @param {string} password The password of the user to confirm the deletion
 * @returns A promise that resolves when the account is successfully deleted
 */
export const deleteAccount = (password) => Promise<void>;
```