### PR TITLE
Add function to change ranking of favorited university

### DIFF
--- a/src/api/Favorites.js
+++ b/src/api/Favorites.js
@@ -33,3 +33,23 @@ export const removeFavorite = (universityId) => {
     method: "DELETE",
   });
 };
+
+/**
+ * Changes the rank of a favorited university for the current user. The university will be swapped with the university
+ * that is currently at the specified rank.
+ * @param {string} universityId The ID of the university to change the rank of
+ * @param {number} newRank The new rank to set for the specified university ID. Must be between 1 and the number of
+ * favorited universities.
+ * @returns A promise that resolves when the ranking for the university is updated
+ */
+export const rankFavorite = (universityId, newRank) => {
+  return callApi(`/favorites/${universityId}/rank`, {
+    method: "PATCH",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      newRank,
+    }),
+  });
+};


### PR DESCRIPTION
This PR allows you to update the ranking of a favorited university. It swaps the university with the university at the specified rank.

For example:
```
1 - Hunter College (ID: 123)
2 - Baruch College (ID: 456)
3 - BMCC (ID: 789)
```

`rankFavorite(456, 1)` will move Baruch College to #1 and Hunter College to #2 like so:
```
1 - Baruch College (ID: 456)
2 - Hunter College (ID: 123)
3 - BMCC (ID: 789)
```

The function definition is as follows:
```typescript
/**
 * Changes the rank of a favorited university for the current user. The university will be swapped with the university
 * that is currently at the specified rank.
 * @param {string} universityId The ID of the university to change the rank of
 * @param {number} newRank The new rank to set for the specified university ID. Must be between 1 and the number of
 * favorited universities.
 * @returns A promise that resolves when the ranking for the university is updated
 */
export const rankFavorite = (universityId, newRank) => Promise<void>;
```


