### PR TITLE
Add missing callApi import for Favorites.js

### DIFF
--- a/src/api/Favorites.js
+++ b/src/api/Favorites.js
@@ -1,3 +1,5 @@
+import { callApi } from "../utils/call-api";
+
 /**
  * Adds a university to the list of favorites for the current user
  * @param {string} universityId The ID of the university to add


### PR DESCRIPTION
Added missing import for `callApi()` in `./src/api/Favorites.js`